### PR TITLE
upgrade zeromq version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sawtooth-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5-vidaloop",
   "description": "An SDK for interacting with the Hyperledger Sawtooth distributed ledger.",
   "keywords": [
     "hyperledger",
@@ -17,13 +17,16 @@
     "compile_protobuf": "node compile_protobuf.js > protobuf/protobuf_bundle.json",
     "prepublish": "npm run compile_protobuf && npm test"
   },
+  "publishConfig": {
+    "registry": "https://nexus.vidaloop.net/repository/npm-es/"
+  },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "protobufjs": "^6.7.3",
     "secp256k1": "^3.2.5",
     "uuid": "^3.0.1",
-    "zeromq": "^4.2.1"
+    "zeromq": "^5.2.8"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
 This lets us build on node 16
  
The package built from this change has already been published to private registry. We  tag the version with `vidaloop` to avoid collision in npm registry with upstream `sawtooth-sdk-javascript`. We can't use scopes or change the name b/c we would loose association from @types package. I have bumped version from 1.0.4 to 1.0.5 b/c this code is actually released as upstream's 1.0.5 package, they just didn't bother changing the version in package.json.
